### PR TITLE
Add 'authorizationHeader' as an option

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ class BrowserProvider {
         this.url += `?token=${this.token}`
       }
     }
+    this.authorizationHeader = options.authorizationHeader
     this.WebSocket = options.WebSocket || globalThis.WebSocket
     this.fetch = options.fetch || globalThis.fetch.bind(globalThis)
   }
@@ -78,6 +79,9 @@ class BrowserProvider {
     }
     if (this.token) {
       headers.Authorization = `Bearer ${this.token}`
+    }
+    if (this.authorizationHeader) {
+      headers.Authorization = this.authorizationHeader
     }
     const response = await this.fetch(this.httpUrl, {
       method: 'POST',


### PR DESCRIPTION
For Infura, I need to pass an authorization header for Basic Auth
instead of a Lotus-style token.

Here's an example ObservableHQ notebook that demonstrates how to
use the new option:

https://observablehq.com/@jimpick/infura-test