### PR TITLE
Add support for other content via options

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ class BrowserProvider {
     this.importUrl =
       options.importUrl || this.httpUrl.replace(/\/rpc\//, '/rest/') + '/import'
     this.transport = options.transport || (url.match(/^http/) ? 'http' : 'ws')
+    this.sendHttpContentType = options.sendHttpContentType || 'text/plain;charset=UTF-8'
     this.id = 0
     this.inflight = new Map()
     this.cancelled = new Map()
@@ -74,7 +75,7 @@ class BrowserProvider {
   async sendHttp (jsonRpcRequest) {
     await this.connect()
     const headers = {
-      'Content-Type': 'text/plain;charset=UTF-8',
+      'Content-Type': this.sendHttpContentType,
       Accept: '*/*'
     }
     if (this.token) {


### PR DESCRIPTION
## Description

I've added support for setting http content type via options. This would be useful when testing with mock json-rpc servers like [open-rpc/mock-server](https://github.com/open-rpc/mock-server) that only accepts `application/json` content type.

## Changelog

- Add support for other content types via options that is used when sending HTTP Requests

